### PR TITLE
docs(template): copyedit deploy template

### DIFF
--- a/cmd/template/canary.go
+++ b/cmd/template/canary.go
@@ -39,22 +39,22 @@ func canary(cmd *cobra.Command, options *templateCanaryOptions, args []string) e
 
 
 	// Strategies root
-	strategiesNode, strategyValuesNode := util.BuildMapNode("strategies","A map of strategies, each of which can be assigned to deployment targets in the targets map.")
+	strategiesNode, strategyValuesNode := util.BuildMapNode("strategies","A map of named strategies that can be assigned to deployment targets in the targets block.")
 	// Strategy1
 	strategy1Node, strategy1ValuesNode := util.BuildMapNode("strategy1",
-		"Specify a strategy. The identifier for a strategy is its name.")
+		"Name for a strategy that you use to refer to it. Used in the target block. This example uses strategy1 as the name.")
 
 	// Canary root
-	canaryNode, canaryValuesNode := util.BuildMapNode("canary","This map key, is the deployment strategy type.")
+	canaryNode, canaryValuesNode := util.BuildMapNode("canary","The deployment strategy type. Use canary.")
 
 	// Steps sequence/array
-	stepsNode, stepsValuesNode := util.BuildSequenceNode("steps", "A list of progressive canary steps.")
+	stepsNode, stepsValuesNode := util.BuildSequenceNode("steps", "The steps for your deployment strategy.")
 
 	// Pause root
 	pause := &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"}
-	pauseNode, pauseValuesNode := util.BuildMapNode("pause", "The map key is the step type")
-	pauseValuesNode.Content = append(pauseValuesNode.Content, util.BuildIntNode("duration", "1", "The duration of the pause before the deployment continues. If duration is not zero, set untilApproved to false.")...)
-	pauseValuesNode.Content = append(pauseValuesNode.Content, util.BuildStringNode("unit", "SECONDS", "")...)
+	pauseNode, pauseValuesNode := util.BuildMapNode("pause", "A pause step type. The pipeline stops until the pause behavior is completed. The pause behavior can be duration or untilApproved. ")
+	pauseValuesNode.Content = append(pauseValuesNode.Content, util.BuildIntNode("duration", "1", "The pause behavior is time (integer) before the deployment continues. If duration is set for this step, omit untilApproved.")...)
+	pauseValuesNode.Content = append(pauseValuesNode.Content, util.BuildStringNode("unit", "seconds", "The unit of time to use for the pause. Can be seconds, minutes, or hours. Required if duration is set.")...)
 	pause.Content = append(pause.Content, pauseNode, pauseValuesNode)
 
 	// Weight root
@@ -65,9 +65,9 @@ func canary(cmd *cobra.Command, options *templateCanaryOptions, args []string) e
 
 	// Pause UntilApproved root
 	pauseUA := &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"}
-	pauseUANode, pauseUAValuesNode := util.BuildMapNode("pause","")
+	pauseUANode, pauseUAValuesNode := util.BuildMapNode("pause","A pause step type. The pipeline stops until the pause behavior is completed.")
 	pauseUAValuesNode.Content = append(pauseUAValuesNode.Content, util.BuildBoolNode("untilApproved", "true",
-		"If set to true, the deployment waits until a manual approval to continue. Only set this to true if duration and unit are not set.")...)
+		"The pause behavior is the deployment waits until a manual approval is given to continue. Only set this to true if there is no duration pause behavior for this step.")...)
 	pauseUA.Content = append(pauseUA.Content, pauseUANode, pauseUAValuesNode)
 
 	stepsValuesNode.Content = append(stepsValuesNode.Content, pause, weight, pauseUA)

--- a/cmd/template/kubernetes.go
+++ b/cmd/template/kubernetes.go
@@ -39,7 +39,7 @@ func buildTemplateKubernetesCore() *yaml.Node {
 	devValuesNode.Content = append(devValuesNode.Content, util.BuildStringNode("account",
 		"<accountName>", "The account name that was assigned to the deployment target when you installed the RNA.")...)
 	devValuesNode.Content = append(devValuesNode.Content, util.BuildStringNode("namespace",
-		"<namespace>", "(Optional) Override the namespaces that are in your manifests")...)
+		"<namespace>", "(Recommended) Set the namespace where the app gets deployed to. Overrides the namespaces that are in your manifests")...)
 	devValuesNode.Content = append(devValuesNode.Content, util.BuildStringNode("strategy",
 		"strategy1", "A named strategy from the strategies block. This example uses the name strategy1.")...)
 	targetValuesNode.Content = append(targetValuesNode.Content, devNode, devValuesNode)

--- a/cmd/template/kubernetes.go
+++ b/cmd/template/kubernetes.go
@@ -50,7 +50,7 @@ func buildTemplateKubernetesCore() *yaml.Node {
 
 	path := &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"}
 	path2 := &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"}
-	path.Content = append(path.Content, util.BuildStringNode("path", "path/to/manifests", "Read all yaml|yml files in the dir and deploy all manifests in that directory.")...)
+	path.Content = append(path.Content, util.BuildStringNode("path", "path/to/manifests", "Read all yaml|yml files in the directory and deploy all the manifests found.")...)
 	path2.Content = append(path2.Content, util.BuildStringNode("path", "path/to/manifest.yaml",
 		"Deploy this specific manifest.")...)
 	manifestValuesNode.Content = append(manifestValuesNode.Content, path, path2)

--- a/cmd/template/kubernetes.go
+++ b/cmd/template/kubernetes.go
@@ -39,7 +39,7 @@ func buildTemplateKubernetesCore() *yaml.Node {
 	devValuesNode.Content = append(devValuesNode.Content, util.BuildStringNode("account",
 		"<accountName>", "The account name that was assigned to the deployment target when you installed the RNA.")...)
 	devValuesNode.Content = append(devValuesNode.Content, util.BuildStringNode("namespace",
-		"<namespace>", "(Recommended) Set the namespace where the app gets deployed to. Overrides the namespaces that are in your manifests")...)
+		"<namespace>", "(Recommended) Set the namespace that the app gets deployed to. Overrides the namespaces that are in your manifests")...)
 	devValuesNode.Content = append(devValuesNode.Content, util.BuildStringNode("strategy",
 		"strategy1", "A named strategy from the strategies block. This example uses the name strategy1.")...)
 	targetValuesNode.Content = append(targetValuesNode.Content, devNode, devValuesNode)

--- a/cmd/template/kubernetes.go
+++ b/cmd/template/kubernetes.go
@@ -28,31 +28,31 @@ func buildTemplateKubernetesCore() *yaml.Node {
 	//Core
 	root.Content = append(root.Content, util.BuildStringNode("version", "v1", "")...)
 	root.Content = append(root.Content, util.BuildStringNode("kind", "kubernetes", "")...)
-	root.Content = append(root.Content, util.BuildStringNode("application", "<App Name>", "The name of the deployed application.")...)
+	root.Content = append(root.Content, util.BuildStringNode("application", "<AppName>", "The name of the application to deploy.")...)
 
 
 	// Target root
-	targetNode, targetValuesNode := util.BuildMapNode("targets","Map of Deployment Targets, " +
-		"Map of deployment targets. You can specify more than one target, but we currently only support deploying to one. Specifying more than one target will be available in a future feature.")
-	devNode, devValuesNode := util.BuildMapNode("dev-west",
-		"Specify a deployment target. The identifier for a deployment target is its name.")
+	targetNode, targetValuesNode := util.BuildMapNode("targets","Map of your deployment target, " +
+		"Borealis supports deploying to one target cluster.")
+	devNode, devValuesNode := util.BuildMapNode("<deploymentName>",
+		"Name for your deployment. Use a descriptive value such as the environment name.")
 	devValuesNode.Content = append(devValuesNode.Content, util.BuildStringNode("account",
-		"account-name", "The name of an agent configured account")...)
+		"<accountName>", "The account name that was assigned to the deployment target when you installed the RNA.")...)
 	devValuesNode.Content = append(devValuesNode.Content, util.BuildStringNode("namespace",
-		"namespace", "Optionally override the namespaces that are in the manifests")...)
+		"<namespace>", "(Optional) Override the namespaces that are in your manifests")...)
 	devValuesNode.Content = append(devValuesNode.Content, util.BuildStringNode("strategy",
-		"strategy1", "This is the key to a strategy specified in the strategies map below")...)
+		"strategy1", "A named strategy from the strategies block. This example uses the name strategy1.")...)
 	targetValuesNode.Content = append(targetValuesNode.Content, devNode, devValuesNode)
 	root.Content = append(root.Content, targetNode, targetValuesNode)
 
 	// Manifest sequence/array
-	manifestsNode, manifestValuesNode := util.BuildSequenceNode("manifests", "The list of manifest sources.")
+	manifestsNode, manifestValuesNode := util.BuildSequenceNode("manifests", "The list of manifest sources. Can be a directory or file.")
 
 	path := &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"}
 	path2 := &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"}
-	path.Content = append(path.Content, util.BuildStringNode("path", "infrastructure/manifests/configmaps", "This will read all yaml|yml files in a dir and deploy all manifests in that directory to all targets.")...)
-	path2.Content = append(path2.Content, util.BuildStringNode("path", "infrastructure/manifests/deployment.yaml",
-		"This will read all yaml|yml files in a dir and deploy all manifests in that directory to all targets.")...)
+	path.Content = append(path.Content, util.BuildStringNode("path", "path/to/manifests", "Read all yaml|yml files in the dir and deploy all manifests in that directory.")...)
+	path2.Content = append(path2.Content, util.BuildStringNode("path", "path/to/manifest.yaml",
+		"Deploy this specific manifest.")...)
 	manifestValuesNode.Content = append(manifestValuesNode.Content, path, path2)
 
 	root.Content = append(root.Content, manifestsNode, manifestValuesNode)


### PR DESCRIPTION
Here is what the output looks like for folks who don't want to build it locally:

```
version: v1
kind: kubernetes
application: <AppName> # The name of the application to deploy.
targets: # Map of your deployment target, Borealis supports deploying to one target cluster.
    <deploymentName>: # Name for your deployment. Use a descriptive value such as the environment name.
        account: <accountName> # The account name that was assigned to the deployment target when you installed the RNA.
        namespace: <namespace> # (Recommended) Set the namespace that the app gets deployed to. Overrides the namespaces that are in your manifests
        strategy: strategy1 # A named strategy from the strategies block. This example uses the name strategy1.
# The list of manifest sources. Can be a directory or file.
manifests:
    - path: path/to/manifests # Read all yaml|yml files in the dir and deploy all manifests in that directory.
    - path: path/to/manifest.yaml # Deploy this specific manifest.
strategies: # A map of named strategies that can be assigned to deployment targets in the targets block.
    strategy1: # Name for a strategy that you use to refer to it. Used in the target block. This example uses strategy1 as the name.
        canary: # The deployment strategy type. Use canary.
            # The steps for your deployment strategy.
            steps:
                - pause: # A pause step type. The pipeline stops until the pause behavior is completed. The pause behavior can be duration or untilApproved.
                    # The pause behavior is time (integer) before the deployment continues. If duration is set for this step, omit untilApproved.
                    duration: 1
                    unit: seconds # The unit of time to use for the pause. Can be seconds, minutes, or hours. Required if duration is set.
                - setWeight:
                    # The percentage of pods that should be running the canary version for this step. Set it to an integer between 0 and 100, inclusive.
                    weight: 33
                - pause: # A pause step type. The pipeline stops until the pause behavior is completed.
                    # The pause behavior is the deployment waits until a manual approval is given to continue. Only set this to true if there is no duration pause behavior for this step.
                    untilApproved: true
```