### PR TITLE
feat(auth): Add option to supply JWT authToken

### DIFF
--- a/cmd/rootCmd.go
+++ b/cmd/rootCmd.go
@@ -21,6 +21,7 @@ type RootOptions struct {
 	deployHostUrl  string
 	TokenIssuerUrl string
 	Environment    string
+	Token          string
 	DeployClient   *deploy.Client
 	Output         *output.Output
 }
@@ -42,7 +43,7 @@ func NewCmdRoot(outWriter, errWriter io.Writer) (*cobra.Command, *RootOptions) {
 		options.Output = output.NewOutput(options.O)
 		auth := auth.NewAuth(
 			options.clientId, options.clientSecret, "client_credentials",
-			options.TokenIssuerUrl, options.audience)
+			options.TokenIssuerUrl, options.audience, options.Token)
 		token, err := auth.GetToken()
 		if err != nil {
 			return fmt.Errorf("error at retrieving a token: %s", err)
@@ -72,6 +73,7 @@ func AddLoginFlags(cmd *cobra.Command, opts *RootOptions) {
 	cmd.PersistentFlags().StringVarP(&opts.clientId, "clientId", "c", "", "configure clientId to configure Armory Cloud")
 	cmd.PersistentFlags().StringVarP(&opts.clientSecret, "clientSecret", "s", "", "configure clientSecret to configure Armory Cloud")
 	cmd.PersistentFlags().StringVarP(&opts.TokenIssuerUrl, "tokenIssuerUrl", "", "https://auth.cloud.armory.io/oauth", "")
+	cmd.PersistentFlags().StringVarP(&opts.Token, "authToken", "a", "", "use an existing token, rather than client id and secret or user login")
 	cmd.PersistentFlags().StringVarP(&opts.audience, "audience", "", "https://api.cloud.armory.io", "")
 	cmd.PersistentFlags().StringVarP(&opts.deployHostUrl, "deployHostUrl", "", "api.cloud.armory.io", "")
 	cmd.PersistentFlags().MarkHidden("tokenIssuerUrl")

--- a/pkg/deploy/service_test.go
+++ b/pkg/deploy/service_test.go
@@ -1,11 +1,14 @@
 package deploy
 
 import (
+	"encoding/json"
+	de "github.com/armory-io/deploy-engine/pkg"
 	"github.com/armory/armory-cli/pkg/model"
 	"github.com/armory/armory-cli/pkg/util"
 	"github.com/stretchr/testify/suite"
 	"io/ioutil"
 	"os"
+	"reflect"
 	"testing"
 )
 
@@ -126,15 +129,17 @@ func (suite *ServiceTestSuite) TestCreateDeploymentRequestSuccess(){
 	if err != nil {
 		suite.T().Fatalf("TestCreateDeploymentRequestSuccess failed with: %s", err)
 	}
-	receivedJson, err := received.MarshalJSON()
-	if err != nil {
-		suite.T().Fatalf("TestCreateDeploymentRequestSuccess failed with: %s", err)
-	}
-	expected, err := ioutil.ReadFile("testdata/deploymentRequest.json")
+
+	expectedJsonStr, err := ioutil.ReadFile("testdata/deploymentRequest.json")
 	if err != nil {
 		suite.T().Fatalf("TestCreateDeploymentRequestSuccess failed with: Error loading tesdata file %s", err)
 	}
-	suite.JSONEq(string(receivedJson), string(expected), "json should be the same")
+	expectedReq := de.PipelineStartPipelineRequest {}
+	err = json.Unmarshal(expectedJsonStr, &expectedReq)
+	if err != nil {
+		suite.T().Fatalf("TestCreateDeploymentRequestSuccess failed with: Error Unmarshalling JSON string to Request obj %s", err)
+	}
+	reflect.DeepEqual(received, expectedReq)
 }
 
 func (suite *ServiceTestSuite) TestGetManifestsFromPathSuccess(){


### PR DESCRIPTION
This aids the Aurora plugin since it will already have a JWT to use when executing the CLI.